### PR TITLE
Add drag-and-drop and Windows file dialog support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(logtoexcel_lib
     src/realitymesh_parser.cpp
     src/util_time.cpp
     src/models.cpp
+    $<$<PLATFORM_ID:Windows>:src/win_file_dialogs.cpp>
 )
 
 # Headers only
@@ -23,11 +24,15 @@ set_target_properties(logtoexcel_lib PROPERTIES
 
 target_include_directories(logtoexcel_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src ${XLSXWRITER_INCLUDE_DIRS})
 
-target_link_libraries(logtoexcel_lib PUBLIC fmt::fmt ${XLSXWRITER_LIBRARIES})
+target_link_libraries(logtoexcel_lib PUBLIC fmt::fmt-header-only ${XLSXWRITER_LIBRARIES})
 
 add_executable(logtoExcel src/main.cpp)
 
 target_link_libraries(logtoExcel PRIVATE logtoexcel_lib)
+
+if (WIN32)
+  target_link_libraries(logtoExcel PRIVATE Ole32 Shell32 Uuid)
+endif()
 
 enable_testing()
 add_subdirectory(tests)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,27 +3,112 @@
 #include "realitymesh_parser.hpp"
 #include "excel_writer.hpp"
 #include "models.hpp"
-#include <fmt/printf.h>
 
-int main(int argc, char **argv) {
+#include <fmt/printf.h>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <combaseapi.h> // CoInitializeEx/CoUninitialize
+#include "win_file_dialogs.hpp"
+#endif
+
+// Simple classifier to detect which parser to use for a raw .log path
+enum class LogKind { PhotoMesh, RealityMesh, Unknown };
+
+static LogKind detect_log_type(const std::string& path) {
+    std::ifstream in(path);
+    if (!in) return LogKind::Unknown;
+    std::string line;
+    size_t limit = 4000; // scan up to ~4k lines
+    while (limit-- && std::getline(in, line)) {
+        // PhotoMesh markers (see photomesh_parser)  [scan order matters]
+        if (line.find("SLDEFAULT=>") != std::string::npos ||
+            line.find("\"MachineName\"") != std::string::npos ||
+            line.find("\"MsgTime\"")    != std::string::npos) {
+            return LogKind::PhotoMesh;
+        }
+        // RealityMesh markers (see realitymesh_parser)
+        if (line.find("Time to run TT project:") != std::string::npos ||
+            line.find("-command_file")           != std::string::npos ||
+            line.find("Process completed with exit code:") != std::string::npos ||
+            line.find("Converted offset:")       != std::string::npos) {
+            return LogKind::RealityMesh;
+        }
+    }
+    return LogKind::Unknown;
+}
+
+static void classify_paths_into_options(const std::vector<std::string>& paths, Options& opt) {
+    for (const auto& p : paths) {
+        switch (detect_log_type(p)) {
+        case LogKind::PhotoMesh:   opt.photomeshLogs.push_back(p);   break;
+        case LogKind::RealityMesh: opt.realitymeshLogs.push_back(p); break;
+        case LogKind::Unknown:     // default to PhotoMesh if unknown
+            opt.photomeshLogs.push_back(p);
+            break;
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    // 1) Parse CLI flags as before (kept compatible)
     Options opt = parse_cli(argc, argv);
+
+    // 2) Drag & drop support: any bare arg that doesn't start with '-' is treated as a raw log path.
+    std::vector<std::string> barePaths;
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (!a.empty() && a[0] != '-') barePaths.push_back(a);
+    }
+    if (!barePaths.empty()) {
+        classify_paths_into_options(barePaths, opt);
+    }
+
+#ifdef _WIN32
+    // 3) GUI path: if user double-clicked the exe (no logs via flags or bare paths), show dialogs
     if (opt.photomeshLogs.empty() && opt.realitymeshLogs.empty()) {
-        fmt::print(stderr, "Usage: logtoExcel --photomesh <pm.log> --realitymesh <rm.log> -o out.xlsx\n");
+        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+
+        auto pmSel = open_logs_dialog(L"Select PhotoMesh log(s)", true);
+        auto rmSel = open_logs_dialog(L"Select RealityMesh log(s)", true);
+
+        classify_paths_into_options(pmSel, opt);
+        classify_paths_into_options(rmSel, opt);
+
+        if (opt.output.empty()) {
+            std::string chosen = save_xlsx_dialog(L"Save Excel report as...", L"Report.xlsx");
+            if (!chosen.empty()) opt.output = chosen;
+        }
+
+        CoUninitialize();
+    }
+#endif
+
+    // 4) Final validation / defaults
+    if (opt.photomeshLogs.empty() && opt.realitymeshLogs.empty()) {
+        fmt::print(stderr,
+            "Drag one or more PhotoMesh/RealityMesh logs onto the EXE,\n"
+            "or run with: logtoExcel --photomesh <pm.log> --realitymesh <rm.log> -o out.xlsx\n");
         return 2;
     }
+    if (opt.output.empty()) opt.output = "Report.xlsx";
+
+    // 5) Parse and write the workbook
     std::vector<PhotoMeshRow> pm_rows;
-    for (const auto &p : opt.photomeshLogs) {
-        pm_rows.push_back(parse_photomesh(p));
-    }
+    for (const auto& p : opt.photomeshLogs) pm_rows.push_back(parse_photomesh(p));
+
     std::vector<RealityMeshRow> rm_rows;
-    for (const auto &p : opt.realitymeshLogs) {
-        rm_rows.push_back(parse_realitymesh(p));
-    }
+    for (const auto& p : opt.realitymeshLogs) rm_rows.push_back(parse_realitymesh(p));
+
     std::vector<SummaryRow> summary;
-    for (const auto &r : pm_rows) summary.push_back(make_summary(r));
-    for (const auto &r : rm_rows) summary.push_back(make_summary(r));
+    for (const auto& r : pm_rows) summary.push_back(make_summary(r));
+    for (const auto& r : rm_rows) summary.push_back(make_summary(r));
+
     excel::write_workbook(opt.output, pm_rows, rm_rows, summary);
-    fmt::print("Parsed {} PhotoMesh rows, {} RealityMesh rows -> {}\n", pm_rows.size(), rm_rows.size(), opt.output);
+    fmt::print("Parsed {} PhotoMesh row(s), {} RealityMesh row(s) -> {}\n",
+               pm_rows.size(), rm_rows.size(), opt.output);
     return 0;
 }
 

--- a/src/win_file_dialogs.cpp
+++ b/src/win_file_dialogs.cpp
@@ -1,0 +1,89 @@
+#ifdef _WIN32
+#include <windows.h>
+#include <shobjidl.h>
+#include <vector>
+#include <string>
+
+static std::string narrow(const std::wstring& ws) {
+    if (ws.empty()) return {};
+    int len = ::WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), (int)ws.size(), nullptr, 0, nullptr, nullptr);
+    std::string out(len, '\0');
+    ::WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), (int)ws.size(), out.data(), len, nullptr, nullptr);
+    return out;
+}
+
+std::vector<std::string> open_logs_dialog(const wchar_t* title, bool allowMulti) {
+    std::vector<std::string> result;
+
+    IFileOpenDialog* dlg = nullptr;
+    HRESULT hr = ::CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dlg));
+    if (FAILED(hr)) return result;
+
+    DWORD opts = 0;
+    if (SUCCEEDED(dlg->GetOptions(&opts))) {
+        if (allowMulti) opts |= FOS_ALLOWMULTISELECT;
+        dlg->SetOptions(opts);
+    }
+    if (title) dlg->SetTitle(title);
+
+    COMDLG_FILTERSPEC filters[] = {
+        { L"Log files (*.log;*.txt)", L"*.log;*.txt" },
+        { L"All files (*.*)",         L"*.*" }
+    };
+    dlg->SetFileTypes((UINT)(sizeof(filters)/sizeof(filters[0])), filters);
+
+    hr = dlg->Show(nullptr);
+    if (SUCCEEDED(hr)) {
+        IShellItemArray* items = nullptr;
+        if (SUCCEEDED(dlg->GetResults(&items))) {
+            DWORD count = 0;
+            items->GetCount(&count);
+            for (DWORD i = 0; i < count; ++i) {
+                IShellItem* it = nullptr;
+                if (SUCCEEDED(items->GetItemAt(i, &it))) {
+                    PWSTR psz = nullptr;
+                    if (SUCCEEDED(it->GetDisplayName(SIGDN_FILESYSPATH, &psz)) && psz) {
+                        result.push_back(narrow(psz));
+                        ::CoTaskMemFree(psz);
+                    }
+                    it->Release();
+                }
+            }
+            items->Release();
+        }
+    }
+    dlg->Release();
+    return result;
+}
+
+std::string save_xlsx_dialog(const wchar_t* title, const std::wstring& suggestedName) {
+    std::string out;
+
+    IFileSaveDialog* dlg = nullptr;
+    HRESULT hr = ::CoCreateInstance(CLSID_FileSaveDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dlg));
+    if (FAILED(hr)) return out;
+
+    if (title) dlg->SetTitle(title);
+
+    COMDLG_FILTERSPEC fs[] = { { L"Excel Workbook (*.xlsx)", L"*.xlsx" } };
+    dlg->SetFileTypes(1, fs);
+    dlg->SetDefaultExtension(L"xlsx");
+    dlg->SetFileName(suggestedName.c_str());
+
+    hr = dlg->Show(nullptr);
+    if (SUCCEEDED(hr)) {
+        IShellItem* item = nullptr;
+        if (SUCCEEDED(dlg->GetResult(&item))) {
+            PWSTR psz = nullptr;
+            if (SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &psz)) && psz) {
+                out = narrow(psz);
+                ::CoTaskMemFree(psz);
+            }
+            item->Release();
+        }
+    }
+    dlg->Release();
+    return out;
+}
+#endif
+

--- a/src/win_file_dialogs.hpp
+++ b/src/win_file_dialogs.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+#include <vector>
+
+// Windows-only helpers. No-ops on non-Windows builds.
+#ifdef _WIN32
+std::vector<std::string> open_logs_dialog(const wchar_t* title, bool allowMulti);
+std::string save_xlsx_dialog(const wchar_t* title, const std::wstring& suggestedName);
+#endif
+


### PR DESCRIPTION
## Summary
- Detect log types from dropped file paths and parse accordingly
- Launch Windows file pickers when no logs are provided via CLI
- Wire up COM libraries and optional Windows dialog helpers in CMake

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68be43e0074083228141a64cd8dae245