### PR TITLE
Add Windows GUI frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ else()
   set(XLSXWRITER_TARGET PkgConfig::XLSXWRITER)
 endif()
 
-# ---------- library ----------
+# ---- shared library stays the same ----
 add_library(logtoexcel_lib
   src/excel_writer.cpp
   src/photomesh_parser.cpp
@@ -58,41 +58,59 @@ add_library(logtoexcel_lib
 target_include_directories(logtoexcel_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(logtoexcel_lib PUBLIC fmt::fmt-header-only ${XLSXWRITER_TARGET})
 
-# ---------- executable ----------
-add_executable(logtoExcel src/main.cpp)
-target_link_libraries(logtoExcel PRIVATE logtoexcel_lib)
-
+# ---- GUI exe (default app on Windows; no startup prompts) ----
 if (WIN32)
-  target_link_libraries(logtoExcel PRIVATE Ole32 Shell32 Uuid)
+  add_executable(logtoExcel_gui WIN32 src/gui_main.cpp)
+  target_link_libraries(logtoExcel_gui PRIVATE logtoexcel_lib Ole32 Shell32 Uuid Comctl32)
+
+  # copy vcpkg runtime DLLs (debug/release) next to the GUI exe
+  if(EXISTS "${_VCPKG_INSTALLED_ROOT}/debug/bin")
+    file(GLOB _VCPKG_DLLS_DEBUG   "${_VCPKG_INSTALLED_ROOT}/debug/bin/*.dll")
+  endif()
+  if(EXISTS "${_VCPKG_INSTALLED_ROOT}/bin")
+    file(GLOB _VCPKG_DLLS_RELEASE "${_VCPKG_INSTALLED_ROOT}/bin/*.dll")
+  endif()
+
+  if(_VCPKG_DLLS_DEBUG)
+    add_custom_command(TARGET logtoExcel_gui POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              ${_VCPKG_DLLS_DEBUG}
+              "$<TARGET_FILE_DIR:logtoExcel_gui>"
+      COMMENT "Copying vcpkg DEBUG DLLs for GUI"
+      VERBATIM
+      CONFIGURATIONS Debug)
+  endif()
+  if(_VCPKG_DLLS_RELEASE)
+    add_custom_command(TARGET logtoExcel_gui POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              ${_VCPKG_DLLS_RELEASE}
+              "$<TARGET_FILE_DIR:logtoExcel_gui>"
+      COMMENT "Copying vcpkg RELEASE DLLs for GUI"
+      VERBATIM
+      CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
+  endif()
 endif()
 
-# ---------- post-build: copy ALL vcpkg runtime DLLs per configuration ----------
-# (solves "minizip.dll not found", "xlsxwriter.dll not found", etc.)
-if(EXISTS "${_VCPKG_INSTALLED_ROOT}/debug/bin")
-  file(GLOB _VCPKG_DLLS_DEBUG   "${_VCPKG_INSTALLED_ROOT}/debug/bin/*.dll")
-endif()
-if(EXISTS "${_VCPKG_INSTALLED_ROOT}/bin")
-  file(GLOB _VCPKG_DLLS_RELEASE "${_VCPKG_INSTALLED_ROOT}/bin/*.dll")
-endif()
+# ---- CLI exe (for scripts/automation; unchanged flags) ----
+add_executable(logtoExcel_cli src/main.cpp)
+target_link_libraries(logtoExcel_cli PRIVATE logtoexcel_lib)
 
-# Debug: copy debug DLLs
+# copy DLLs for CLI too
 if(_VCPKG_DLLS_DEBUG)
-  add_custom_command(TARGET logtoExcel POST_BUILD
+  add_custom_command(TARGET logtoExcel_cli POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
             ${_VCPKG_DLLS_DEBUG}
-            "$<TARGET_FILE_DIR:logtoExcel>"
-    COMMENT "Copying vcpkg DEBUG DLLs"
+            "$<TARGET_FILE_DIR:logtoExcel_cli>"
+    COMMENT "Copying vcpkg DEBUG DLLs for CLI"
     VERBATIM
     CONFIGURATIONS Debug)
 endif()
-
-# Release (and similar): copy release DLLs
 if(_VCPKG_DLLS_RELEASE)
-  add_custom_command(TARGET logtoExcel POST_BUILD
+  add_custom_command(TARGET logtoExcel_cli POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
             ${_VCPKG_DLLS_RELEASE}
-            "$<TARGET_FILE_DIR:logtoExcel>"
-    COMMENT "Copying vcpkg RELEASE DLLs"
+            "$<TARGET_FILE_DIR:logtoExcel_cli>"
+    COMMENT "Copying vcpkg RELEASE DLLs for CLI"
     VERBATIM
     CONFIGURATIONS Release RelWithDebInfo MinSizeRel)
 endif()

--- a/src/gui_main.cpp
+++ b/src/gui_main.cpp
@@ -1,0 +1,312 @@
+#include "photomesh_parser.hpp"
+#include "realitymesh_parser.hpp"
+#include "excel_writer.hpp"
+#include "single_sheet_writer.hpp"
+#include "models.hpp"
+#include "util_time.hpp"
+
+#include <windows.h>
+#include <shellapi.h>
+#include <shobjidl.h>
+#include <commctrl.h>
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+
+#pragma comment(lib, "Comctl32.lib")
+#pragma comment(lib, "Ole32.lib")
+#pragma comment(lib, "Shell32.lib")
+#pragma comment(lib, "Uuid.lib")
+
+namespace fs = std::filesystem;
+
+// ---------------------- small helpers ----------------------
+static std::string narrow(const std::wstring& ws) {
+    if (ws.empty()) return {};
+    int len = ::WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), (int)ws.size(), nullptr, 0, nullptr, nullptr);
+    std::string out(len, '\0');
+    ::WideCharToMultiByte(CP_UTF8, 0, ws.c_str(), (int)ws.size(), out.data(), len, nullptr, nullptr);
+    return out;
+}
+static std::wstring widen(const std::string& s) {
+    if (s.empty()) return {};
+    int len = ::MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), nullptr, 0);
+    std::wstring out(len, L'\0');
+    ::MultiByteToWideChar(CP_UTF8, 0, s.c_str(), (int)s.size(), out.data(), len);
+    return out;
+}
+static std::string exe_dir() {
+    wchar_t buf[MAX_PATH]; ::GetModuleFileNameW(nullptr, buf, MAX_PATH);
+    fs::path p(buf); return p.parent_path().string();
+}
+static void ensure_dir(const std::string& d) {
+    std::error_code ec; fs::create_directories(fs::path(d), ec);
+}
+
+// ---------------------- classification ----------------------
+enum class LogKind { PhotoMesh, RealityMesh, Unknown };
+
+static LogKind detect_log_type(const std::string& path) {
+    std::ifstream in(path);
+    if (!in) return LogKind::Unknown;
+    std::string line; size_t limit = 4000;
+    while (limit-- && std::getline(in, line)) {
+        // PhotoMesh markers
+        if (line.find("SLDEFAULT=>") != std::string::npos ||
+            line.find("\"MachineName\"") != std::string::npos ||
+            line.find("\"MsgTime\"")    != std::string::npos) {
+            return LogKind::PhotoMesh;
+        }
+        // RealityMesh markers
+        if (line.find("Time to run TT project:") != std::string::npos ||
+            line.find("-command_file")           != std::string::npos ||
+            line.find("Process completed with exit code:") != std::string::npos ||
+            line.find("Converted offset:")       != std::string::npos) {
+            return LogKind::RealityMesh;
+        }
+    }
+    return LogKind::Unknown;
+}
+
+// ---------------------- UI state ----------------------
+enum class Mode { MasterOnly, ReportOnly, Both };
+struct UIState {
+    std::vector<std::string> dropPaths;
+    Mode mode = Mode::Both;
+    std::string outputsDir = exe_dir() + "/EXCEL OUTPUTS";
+};
+
+static UIState g;
+
+// ---------------------- pipeline ----------------------
+static void run_pipeline(HWND hwndLog) {
+    SendMessage(hwndLog, EM_SETSEL, (WPARAM)-1, (LPARAM)-1);
+    auto append = [&](const std::string& s){
+        std::wstring w = widen(s + "\r\n");
+        SendMessage(hwndLog, EM_REPLACESEL, FALSE, (LPARAM)w.c_str());
+    };
+
+    if (g.dropPaths.empty()) { append("[!] No logs to process."); return; }
+
+    std::vector<std::string> pmFiles, rmFiles;
+    for (auto& p : g.dropPaths) {
+        switch (detect_log_type(p)) {
+            case LogKind::PhotoMesh:   pmFiles.push_back(p); break;
+            case LogKind::RealityMesh: rmFiles.push_back(p); break;
+            default: // unknown -> try both parsers safely
+                pmFiles.push_back(p); rmFiles.push_back(p); break;
+        }
+    }
+
+    append("[*] Parsing logs...");
+    std::vector<PhotoMeshRow> pm_rows;
+    for (auto &p : pmFiles) pm_rows.push_back(parse_photomesh(p));  // safe to parse; row stays mostly empty if unmatched
+    std::vector<RealityMeshRow> rm_rows;
+    for (auto &p : rmFiles) rm_rows.push_back(parse_realitymesh(p));
+
+    // Filter out rows that are completely empty (no success, no machine, no duration)
+    auto pm_end = std::remove_if(pm_rows.begin(), pm_rows.end(), [](const PhotoMeshRow& r){
+        return r.machine.empty() && r.duration.empty() && r.success.empty() && r.exportType.empty();
+    });
+    pm_rows.erase(pm_end, pm_rows.end());
+    auto rm_end = std::remove_if(rm_rows.begin(), rm_rows.end(), [](const RealityMeshRow& r){
+        return r.machine.empty() && r.duration.empty() && r.success.empty() && r.exportType.empty();
+    });
+    rm_rows.erase(rm_end, rm_rows.end());
+
+    ensure_dir(g.outputsDir);
+
+    // Master single-sheet (append + rebuild)
+    if (g.mode == Mode::MasterOnly || g.mode == Mode::Both) {
+        auto unified = excel::unify(pm_rows, rm_rows);
+        excel::append_to_master_and_rebuild_xlsx(g.outputsDir, unified);
+        append("[+] Updated master: " + g.outputsDir + "/All_Exports.xlsx");
+    }
+
+    // Per-run report (multi-sheet)
+    if (g.mode == Mode::ReportOnly || g.mode == Mode::Both) {
+        std::vector<SummaryRow> summary;
+        for (const auto &r : pm_rows) summary.push_back(make_summary(r));
+        for (const auto &r : rm_rows) summary.push_back(make_summary(r));
+        const std::string out = g.outputsDir + "/Report.xlsx";
+        excel::write_workbook(out, pm_rows, rm_rows, summary);
+        append("[+] Wrote per-run report: " + out);
+    }
+
+    append("[\u2713] Done.");
+    g.dropPaths.clear();
+}
+
+// ---------------------- UI creation ----------------------
+#define IDC_RAD_MASTER   1001
+#define IDC_RAD_REPORT   1002
+#define IDC_RAD_BOTH     1003
+#define IDC_BTN_CHOOSE   1004
+#define IDC_BTN_RUN      1005
+#define IDC_BTN_OPEN     1006
+#define IDC_EDIT_LOG     1007
+
+static HFONT g_hFontTitle = nullptr;
+static HFONT g_hFontBase  = nullptr;
+
+static void create_fonts() {
+    LOGFONTW lf{}; lf.lfHeight = -18; lf.lfWeight = FW_SEMIBOLD; wcscpy_s(lf.lfFaceName, L"Segoe UI");
+    g_hFontTitle = CreateFontIndirectW(&lf);
+    lf = {}; lf.lfHeight = -15; wcscpy_s(lf.lfFaceName, L"Segoe UI");
+    g_hFontBase = CreateFontIndirectW(&lf);
+}
+
+static void paint_dropzone(HDC hdc, RECT rc) {
+    HBRUSH bg = CreateSolidBrush(RGB(248,248,248));
+    FillRect(hdc, &rc, bg); DeleteObject(bg);
+
+    HPEN pen = CreatePen(PS_DOT, 1, RGB(150,150,150));
+    HGDIOBJ oldPen = SelectObject(hdc, pen);
+    HGDIOBJ oldBrush = SelectObject(hdc, GetStockObject(NULL_BRUSH));
+    Rectangle(hdc, rc.left, rc.top, rc.right, rc.bottom);
+    SelectObject(hdc, oldBrush); SelectObject(hdc, oldPen); DeleteObject(pen);
+
+    SetBkMode(hdc, TRANSPARENT);
+    HFONT old = (HFONT)SelectObject(hdc, g_hFontTitle);
+    const wchar_t* title = L"Drag and drop logs here";
+    DrawTextW(hdc, title, -1, &rc, DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+    SelectObject(hdc, old);
+}
+
+// ---------------------- Win32 Window Proc ----------------------
+static LRESULT CALLBACK WndProc(HWND h, UINT msg, WPARAM w, LPARAM l) {
+    static HWND hRadMaster, hRadReport, hRadBoth, hBtnChoose, hBtnRun, hBtnOpen, hEditLog;
+    static RECT dropRc{40, 80, 760, 280};
+
+    switch (msg) {
+        case WM_CREATE: {
+            create_fonts();
+            // radios
+            hRadMaster = CreateWindowW(L"BUTTON", L"Append to Master",
+                WS_CHILD|WS_VISIBLE|BS_AUTORADIOBUTTON, 40, 20, 180, 24, h, (HMENU)IDC_RAD_MASTER, nullptr, nullptr);
+            hRadReport = CreateWindowW(L"BUTTON", L"Run Report",
+                WS_CHILD|WS_VISIBLE|BS_AUTORADIOBUTTON, 230, 20, 140, 24, h, (HMENU)IDC_RAD_REPORT, nullptr, nullptr);
+            hRadBoth   = CreateWindowW(L"BUTTON", L"Both (Default)",
+                WS_CHILD|WS_VISIBLE|BS_AUTORADIOBUTTON, 380, 20, 160, 24, h, (HMENU)IDC_RAD_BOTH, nullptr, nullptr);
+            SendMessage(hRadBoth, BM_SETCHECK, BST_CHECKED, 0);
+
+            // buttons
+            hBtnChoose = CreateWindowW(L"BUTTON", L"Choose Logs…", WS_CHILD|WS_VISIBLE, 40, 320, 140, 28, h, (HMENU)IDC_BTN_CHOOSE, nullptr, nullptr);
+            hBtnRun    = CreateWindowW(L"BUTTON", L"Run",          WS_CHILD|WS_VISIBLE, 190,320, 80, 28, h, (HMENU)IDC_BTN_RUN, nullptr, nullptr);
+            hBtnOpen   = CreateWindowW(L"BUTTON", L"Open Output Folder", WS_CHILD|WS_VISIBLE, 280, 320, 200, 28, h, (HMENU)IDC_BTN_OPEN, nullptr, nullptr);
+
+            // status log (read-only, multiline)
+            hEditLog = CreateWindowW(L"EDIT", L"", WS_CHILD|WS_VISIBLE|WS_VSCROLL|ES_MULTILINE|ES_READONLY,
+                                     40, 360, 760, 180, h, (HMENU)IDC_EDIT_LOG, nullptr, nullptr);
+
+            SendMessage(hRadMaster, WM_SETFONT, (WPARAM)g_hFontBase, TRUE);
+            SendMessage(hRadReport, WM_SETFONT, (WPARAM)g_hFontBase, TRUE);
+            SendMessage(hRadBoth,   WM_SETFONT, (WPARAM)g_hFontBase, TRUE);
+            SendMessage(hBtnChoose, WM_SETFONT, (WPARAM)g_hFontBase, TRUE);
+            SendMessage(hBtnRun,    WM_SETFONT, (WPARAM)g_hFontBase, TRUE);
+            SendMessage(hBtnOpen,   WM_SETFONT, (WPARAM)g_hFontBase, TRUE);
+            SendMessage(hEditLog,   WM_SETFONT, (WPARAM)g_hFontBase, TRUE);
+
+            DragAcceptFiles(h, TRUE);
+            return 0;
+        }
+        case WM_PAINT: {
+            PAINTSTRUCT ps; HDC hdc = BeginPaint(h, &ps);
+            paint_dropzone(hdc, dropRc);
+            EndPaint(h, &ps);
+            return 0;
+        }
+        case WM_DROPFILES: {
+            HDROP hd = (HDROP)w;
+            UINT count = DragQueryFileW(hd, 0xFFFFFFFF, nullptr, 0);
+            for (UINT i=0;i<count;++i) {
+                wchar_t path[MAX_PATH]; DragQueryFileW(hd, i, path, MAX_PATH);
+                g.dropPaths.push_back(narrow(path));
+            }
+            DragFinish(hd);
+            // Auto-run on drop
+            run_pipeline(GetDlgItem(h, IDC_EDIT_LOG));
+            InvalidateRect(h, &dropRc, FALSE);
+            return 0;
+        }
+        case WM_COMMAND: {
+            switch (LOWORD(w)) {
+                case IDC_RAD_MASTER: g.mode = Mode::MasterOnly; break;
+                case IDC_RAD_REPORT: g.mode = Mode::ReportOnly; break;
+                case IDC_RAD_BOTH:   g.mode = Mode::Both;       break;
+                case IDC_BTN_CHOOSE: {
+                    // Use standard picker
+                    IFileOpenDialog* dlg = nullptr;
+                    if (SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&dlg)))) {
+                        DWORD opts=0; dlg->GetOptions(&opts); dlg->SetOptions(opts | FOS_ALLOWMULTISELECT);
+                        COMDLG_FILTERSPEC filters[] = { { L"Log files (*.log;*.txt)", L"*.log;*.txt" }, { L"All files (*.*)", L"*.*" } };
+                        dlg->SetFileTypes(2, filters);
+                        if (SUCCEEDED(dlg->Show(nullptr))) {
+                            IShellItemArray* items = nullptr;
+                            if (SUCCEEDED(dlg->GetResults(&items))) {
+                                DWORD n=0; items->GetCount(&n);
+                                for (DWORD i=0;i<n;++i) {
+                                    IShellItem* it=nullptr; if (SUCCEEDED(items->GetItemAt(i, &it))) {
+                                        PWSTR psz=nullptr; if (SUCCEEDED(it->GetDisplayName(SIGDN_FILESYSPATH, &psz)) && psz) {
+                                            g.dropPaths.push_back(narrow(psz)); CoTaskMemFree(psz);
+                                        }
+                                        it->Release();
+                                    }
+                                }
+                                items->Release();
+                            }
+                        }
+                        dlg->Release();
+                    }
+                    break;
+                }
+                case IDC_BTN_RUN: {
+                    run_pipeline(GetDlgItem(h, IDC_EDIT_LOG));
+                    break;
+                }
+                case IDC_BTN_OPEN: {
+                    ensure_dir(g.outputsDir);
+                    ::ShellExecuteW(nullptr, L"open", widen(g.outputsDir).c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+                    break;
+                }
+            }
+            return 0;
+        }
+        case WM_DESTROY: {
+            if (g_hFontTitle) DeleteObject(g_hFontTitle);
+            if (g_hFontBase)  DeleteObject(g_hFontBase);
+            PostQuitMessage(0);
+            return 0;
+        }
+    }
+    return DefWindowProc(h, msg, w, l);
+}
+
+int APIENTRY wWinMain(HINSTANCE hInst, HINSTANCE, LPWSTR, int nCmd) {
+    CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+    INITCOMMONCONTROLSEX icc{sizeof(icc), ICC_STANDARD_CLASSES}; InitCommonControlsEx(&icc);
+
+    const wchar_t* cls = L"LogToExcel.GUI";
+    WNDCLASSEXW wc{sizeof(wc)}; wc.hInstance = hInst; wc.lpszClassName = cls;
+    wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    wc.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
+    wc.lpfnWndProc = WndProc;
+    RegisterClassExW(&wc);
+
+    RECT wr{0,0,840,600};
+    AdjustWindowRect(&wr, WS_OVERLAPPEDWINDOW, FALSE);
+    HWND hWnd = CreateWindowExW(0, cls, L"Log to Excel", WS_OVERLAPPEDWINDOW,
+                                CW_USEDEFAULT, CW_USEDEFAULT, wr.right-wr.left, wr.bottom-wr.top,
+                                nullptr, nullptr, hInst, nullptr);
+    ShowWindow(hWnd, nCmd); UpdateWindow(hWnd);
+
+    MSG msg;
+    while (GetMessage(&msg, nullptr, 0, 0) > 0) {
+        TranslateMessage(&msg); DispatchMessage(&msg);
+    }
+    CoUninitialize();
+    return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,10 +10,6 @@
 #include <string>
 #include <vector>
 
-#ifdef _WIN32
-#include <combaseapi.h>
-#include "win_file_dialogs.hpp" // optional, if you added GUI earlier
-#endif
 
 namespace fs = std::filesystem;
 
@@ -48,24 +44,9 @@ int main(int argc, char **argv) {
   std::string outputsDir; bool doMaster, doReport;
   parse_extra_flags(argc, argv, outputsDir, doMaster, doReport);
 
-#ifdef _WIN32
-  if (opt.photomeshLogs.empty() && opt.realitymeshLogs.empty()) {
-    CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-    auto pm = open_logs_dialog(L"Select PhotoMesh log(s)", true);
-    auto rm = open_logs_dialog(L"Select RealityMesh log(s)", true);
-    for (auto& s : pm) opt.photomeshLogs.push_back(s);
-    for (auto& s : rm) opt.realitymeshLogs.push_back(s);
-    if (opt.output.empty()) {
-      std::string save = save_xlsx_dialog(L"Save per-run report (optional)", L"Report.xlsx");
-      if (!save.empty()) opt.output = save; else doReport = false;
-    }
-    CoUninitialize();
-  }
-#endif
-
   if (opt.photomeshLogs.empty() && opt.realitymeshLogs.empty()) {
     fmt::print(stderr,
-      "Usage: logtoExcel --photomesh <pm.log> --realitymesh <rm.log> -o out.xlsx "
+      "Usage: logtoExcel_cli --photomesh <pm.log> --realitymesh <rm.log> -o out.xlsx "
       "[--outputs-dir <folder>] [--no-master] [--no-report|--single-only]\n");
     return 2;
   }


### PR DESCRIPTION
## Summary
- Build dedicated GUI and CLI executables from shared library
- Remove automatic file dialogs from CLI and provide usage output when no logs are supplied

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cmake -DTEST_EXE=./logtoExcel_cli -P ../tests/run_basic_test.cmake`


------
https://chatgpt.com/codex/tasks/task_e_68be5c5dbb488322af37ab13c4200ea0

## Summary by Sourcery

Introduce a Win32 GUI frontend alongside a streamlined CLI executable by updating CMake to build both targets and handle runtime dependencies, while removing automatic dialogs from the CLI and providing usage output when no logs are supplied.

New Features:
- Add a Windows GUI executable (logtoExcel_gui) with drag-and-drop UI and file picker dialogs

Enhancements:
- Split the build into dedicated GUI and CLI executables from the shared library and bundle vcpkg DLLs for each