### PR TITLE
feat(gui): add modern theming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 # ===== GUI exe (WIN32 subsystem) — the one you launch by default =====
 if (WIN32)
   add_executable(logtoExcel_gui WIN32 src/gui_main.cpp)
-  target_link_libraries(logtoExcel_gui PRIVATE logtoexcel_lib Ole32 Shell32 Uuid Comctl32)
+  target_link_libraries(logtoExcel_gui PRIVATE logtoexcel_lib Ole32 Shell32 Uuid Comctl32 Dwmapi UxTheme)
 
   # Copy vcpkg runtime DLLs next to the GUI exe
   if(_VCPKG_DLLS_DEBUG)


### PR DESCRIPTION
## Summary
- add dark/light theme support with Mica backdrop and per-monitor DPI
- theme controls and drop zone with accent colors and rounded borders
- link Dwmapi and UxTheme libraries

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68bf34eef3f48322a5a924fa3b9b54f6

## Summary by Sourcery

Add modern theming and DPI support to the GUI by introducing dark/light modes, dynamic accent colors, rounded drop zone styling, and Windows 11 Mica backdrop, and update the build to link necessary DWM and UxTheme libraries.

New Features:
- Support dark and light application themes based on system settings with dynamic colors and brushes
- Enable Windows 11 Mica backdrop and immersive dark mode on the main window
- Enable per-monitor DPI awareness for sharp text on high-resolution displays

Enhancements:
- Apply accent-colored rounded borders and themed controls in the drag-and-drop drop zone
- Handle theme change notifications to reload and repaint the UI dynamically
- Adopt the Explorer visual style for standard controls

Build:
- Link the GUI executable against Dwmapi and UxTheme libraries