### PR TITLE
Fix GUI window sizing and clamp layout for small screens

### DIFF
--- a/src/gui_main.cpp
+++ b/src/gui_main.cpp
@@ -295,22 +295,43 @@ static void layout_controls(HWND h,
     const int MARGIN  = 48;
     const int GUTTER  = 16;
     const int lineH   = 34;
+    const int btnH    = lineH + 4;
 
-    // Radios in a row, a bit larger spacing
+    // Absolute minimums so nothing gets cut off
+    const int MIN_DROP_H    = 160;
+    const int MIN_CONSOLE_H = 160;
+
+    // Radios in a row
     const int headerY = 20;
     MoveWindow(hRadMaster, MARGIN,                 headerY, 200, lineH, TRUE);
     MoveWindow(hRadReport, MARGIN + 200 + GUTTER,  headerY, 160, lineH, TRUE);
     MoveWindow(hRadBoth,   MARGIN + 200 + GUTTER + 160 + GUTTER, headerY, 180, lineH, TRUE);
 
-    // Drop zone ~= top 45% of client
+    // Top of drop zone
     int top = 84;
-    int dropH = (rc.bottom - top - MARGIN) * 45 / 100;
+
+    // Available vertical pixels below 'top' down to bottom margin
+    int avail = rc.bottom - top - MARGIN;
+    if (avail < 0) avail = 0;
+
+    // We need: dropH + 24 + btnH + 24 + consoleH  <= avail
+    // Start with drop zone as 45% of available, then clamp so console can have MIN_CONSOLE_H
+    int dropPreferred = (avail * 45) / 100;
+    int minRequiredBelowDrop = 24 + btnH + 24 + MIN_CONSOLE_H;
+    int dropH = dropPreferred;
+
+    // clamp dropH to [MIN_DROP_H, avail - minRequiredBelowDrop]
+    if (dropH < MIN_DROP_H) dropH = MIN_DROP_H;
+    if (dropH > avail - minRequiredBelowDrop) dropH = avail - minRequiredBelowDrop;
+    if (dropH < MIN_DROP_H) dropH = std::max(80, avail - minRequiredBelowDrop); // last resort
+
+    // Lay out drop zone
     dropRc.left   = MARGIN;
     dropRc.top    = top;
     dropRc.right  = rc.right - MARGIN;
-    dropRc.bottom = top + dropH;
+    dropRc.bottom = top + std::max(0, dropH);
 
-    // Buttons row (bigger sizes & clearer spacing)
+    // Buttons row
     int by = dropRc.bottom + 24;
     int x  = MARGIN;
 
@@ -319,18 +340,42 @@ static void layout_controls(HWND h,
     int wOpen   = 260;
     int wSett   = 140;
 
-    MoveWindow(hBtnChoose,   x,          by, wChoose, lineH + 4, TRUE);
+    MoveWindow(hBtnChoose,   x,          by, wChoose, btnH, TRUE);
     x += wChoose + GUTTER;
-    MoveWindow(hBtnRun,      x,          by, wRun,    lineH + 4, TRUE);
+    MoveWindow(hBtnRun,      x,          by, wRun,    btnH, TRUE);
     x += wRun + GUTTER;
-    MoveWindow(hBtnOpen,     x,          by, wOpen,   lineH + 4, TRUE);
+    MoveWindow(hBtnOpen,     x,          by, wOpen,   btnH, TRUE);
+    // Settings anchored to right margin
+    MoveWindow(hBtnSettings, rc.right - MARGIN - wSett, by, wSett, btnH, TRUE);
 
-    // Settings button anchored to the right margin
-    MoveWindow(hBtnSettings, rc.right - MARGIN - wSett, by, wSett, lineH + 4, TRUE);
-
-    // Console occupies the rest
+    // Console fills the rest
     int logTop = by + 24;
-    MoveWindow(hEditLog, MARGIN, logTop, rc.right - 2 * MARGIN, rc.bottom - logTop - MARGIN, TRUE);
+    int logH   = rc.bottom - logTop - MARGIN;
+
+    // If console would be too small, steal space from drop zone and recompute
+    if (logH < MIN_CONSOLE_H) {
+        int need = MIN_CONSOLE_H - logH;
+        // Shrink drop zone, but not below MIN_DROP_H
+        int currentDropH = dropRc.bottom - dropRc.top;
+        int newDropH = std::max(MIN_DROP_H, currentDropH - need);
+
+        dropRc.bottom = dropRc.top + newDropH;
+
+        // Recompute positions with the updated dropRc
+        by = dropRc.bottom + 24;
+        x  = MARGIN;
+        MoveWindow(hBtnChoose,   x,          by, wChoose, btnH, TRUE);
+        x += wChoose + GUTTER;
+        MoveWindow(hBtnRun,      x,          by, wRun,    btnH, TRUE);
+        x += wRun + GUTTER;
+        MoveWindow(hBtnOpen,     x,          by, wOpen,   btnH, TRUE);
+        MoveWindow(hBtnSettings, rc.right - MARGIN - wSett, by, wSett, btnH, TRUE);
+
+        logTop = by + 24;
+        logH   = std::max(MIN_CONSOLE_H, rc.bottom - logTop - MARGIN);
+    }
+
+    MoveWindow(hEditLog, MARGIN, logTop, rc.right - 2 * MARGIN, std::max(0, logH), TRUE);
 }
 
 static void apply_fullscreen(HWND h, bool enable) {
@@ -464,6 +509,13 @@ static LRESULT CALLBACK WndProc(HWND h, UINT msg, WPARAM w, LPARAM l) {
                             hBtnChoose,hBtnRun,hBtnOpen,hBtnSettings,
                             hEditLog, dropRc);
             return 0;
+        case WM_DPICHANGED: {
+            const RECT* pr = reinterpret_cast<const RECT*>(l);
+            SetWindowPos(h, nullptr, pr->left, pr->top,
+                         pr->right - pr->left, pr->bottom - pr->top,
+                         SWP_NOZORDER | SWP_NOACTIVATE);
+            return 0;
+        }
         case WM_PAINT: {
             PAINTSTRUCT ps; HDC hdc = BeginPaint(h, &ps);
 
@@ -590,11 +642,27 @@ int APIENTRY wWinMain(HINSTANCE hInst, HINSTANCE, LPWSTR, int nCmd) {
     wc.lpfnWndProc = WndProc;
     RegisterClassExW(&wc);
 
-    RECT wr{0,0,1680,1200};
-    AdjustWindowRect(&wr, WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX, FALSE);
+    // Pick a size that fits the current work area (taskbar excluded), then center
+    RECT wa; SystemParametersInfoW(SPI_GETWORKAREA, 0, &wa, 0);
+    int workW = wa.right  - wa.left;
+    int workH = wa.bottom - wa.top;
+
+    // Target ~80% of work area, but don't go below a usable minimum
+    int targetW = std::max(1100, (workW * 80) / 100);
+    int targetH = std::max( 720, (workH * 75) / 100);
+
+    RECT wr{0,0,targetW,targetH};
+    AdjustWindowRectEx(&wr, WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX, FALSE, 0);
+    int winW = wr.right - wr.left;
+    int winH = wr.bottom - wr.top;
+
+    // Center within work area
+    int posX = wa.left + (workW - winW) / 2;
+    int posY = wa.top  + (workH - winH) / 2;
+
     HWND hWnd = CreateWindowExW(0, cls, L"Log to Excel",
                                 WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX,
-                                CW_USEDEFAULT, CW_USEDEFAULT, wr.right-wr.left, wr.bottom-wr.top,
+                                posX, posY, winW, winH,
                                 nullptr, nullptr, hInst, nullptr);
     apply_backdrop(hWnd);
     ShowWindow(hWnd, nCmd); UpdateWindow(hWnd);


### PR DESCRIPTION
## Summary
- Clamp layout to maintain visible button row and console even on small/high-DPI screens
- Create window sized and centered to current monitor's work area instead of fixed 1680x1200
- Handle WM_DPICHANGED to apply OS-recommended size when DPI changes

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "fmt")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68c00a5b49ac83228c4aaf409c30dcea

## Summary by Sourcery

Improve GUI layout on small and high-DPI screens by clamping control areas, introducing dynamic window sizing and centering, and handling DPI change events.

New Features:
- Handle WM_DPICHANGED to resize and reposition the window according to OS-recommended dimensions

Enhancements:
- Compute initial window dimensions from the current monitor’s work area (80% width, 75% height with minimums) and center it instead of using a fixed size
- Enforce minimum heights for the drop zone and console and clamp their sizes to ensure the button row and console remain visible on small screens
- Adjust button row height and reflow controls when the console area is too small to maintain usability