### PR TITLE
Improve Excel formatting and DPI handling

### DIFF
--- a/src/excel_writer.cpp
+++ b/src/excel_writer.cpp
@@ -1,98 +1,337 @@
 #include "excel_writer.hpp"
+#include "util_time.hpp"
+
 #include <xlsxwriter.h>
-#include <fmt/format.h>
+
+#include <algorithm>
+#include <chrono>
 #include <set>
+#include <string>
+#include <vector>
 
 namespace {
-std::vector<std::string> pm_headers = {
-"ProjectName","BuildID","Machine","HostIP","User","StartTime","EndTime","Duration(hh:mm:ss)","ExportType","Resolution","TileScheme","PhotosUsed","PhotoFolders","PhotoCoverage(km²)","FusersUsed","CPUThreads","GPUCount","OutputFolder","TotalFiles","TotalSize(GB)","Offset_CoordSys","Offset_HDatum","Offset_VDatum","OffsetX","OffsetY","OffsetZ","PivotCenterX","PivotCenterY","PivotCenterZ","FlipYZ","Trim","Collision","VisualLOD","Success","Warnings","Errors","LogPath"};
 
-std::vector<std::string> rm_headers = {
-"ProjectName","DatasetName","Machine","HostIP","User","StartTime","EndTime","Duration(hh:mm:ss)","ProcessPreset","ExportType","SelAreaSize(km²)","Resolution","TileScheme","Offset_CoordSys","Offset_HDatum","Offset_VDatum","OffsetX","OffsetY","OffsetZ","FlipYZ","Trim","Collision","OutputFolder","TotalFiles","TotalSize(GB)","Success","Warnings","Errors","LogPath"};
+struct ColumnSpec {
+    std::string title;
+    std::string group;
+    double      width;
+    bool        wrap;
+};
 
-std::vector<std::string> summary_headers = {
-"ProjectName","RunDate","Tool","ExportType","Duration(hh:mm:ss)","TotalSize(GB)","PhotosUsed","FusersUsed","Machine","Success","Errors"};
+template <typename Row>
+struct ColumnWithMember {
+    ColumnSpec spec;
+    const std::string Row::* member;
+};
+
+using Clock = std::chrono::system_clock;
+
+Clock::time_point parse_time_or_min(const std::string& primary,
+                                    const std::string& fallback = {}) {
+    if (auto t = util::parse_time(primary)) return *t;
+    if (!fallback.empty())
+        if (auto t = util::parse_time(fallback)) return *t;
+    return Clock::time_point::min();
 }
 
-namespace excel {
-
-static void write_rows(lxw_worksheet *ws, const std::vector<std::string> &headers, const std::vector<std::vector<std::string>> &rows) {
-    for (size_t c=0;c<headers.size();++c)
-        worksheet_write_string(ws,0,c,headers[c].c_str(),NULL);
-    for (size_t r=0;r<rows.size();++r)
-        for (size_t c=0;c<rows[r].size();++c)
-            worksheet_write_string(ws,r+1,c,rows[r][c].c_str(),NULL);
-    worksheet_add_table(ws,0,0,rows.size(),headers.size()-1,NULL);
-    worksheet_freeze_panes(ws,1,0);
-    worksheet_set_column(ws,0,headers.size()-1,20,NULL);
+Clock::time_point parse_date_or_min(const std::string& date_only) {
+    if (date_only.empty()) return Clock::time_point::min();
+    return util::parse_time(date_only + " 00:00:00").value_or(Clock::time_point::min());
 }
 
-static void add_success_format(lxw_workbook *wb, lxw_worksheet *ws, int col, size_t rows) {
-    lxw_format *green = workbook_add_format(wb);
+template <typename Row>
+std::vector<std::vector<std::string>>
+materialize_rows(const std::vector<Row>& rows,
+                 const std::vector<ColumnWithMember<Row>>& columns) {
+    std::vector<std::vector<std::string>> out;
+    out.reserve(rows.size());
+    for (const auto& r : rows) {
+        std::vector<std::string> row;
+        row.reserve(columns.size());
+        for (const auto& c : columns) {
+            row.push_back(r.*(c.member));
+        }
+        out.push_back(std::move(row));
+    }
+    return out;
+}
+
+template <typename Row>
+std::vector<ColumnSpec> collect_specs(const std::vector<ColumnWithMember<Row>>& columns) {
+    std::vector<ColumnSpec> specs;
+    specs.reserve(columns.size());
+    for (const auto& c : columns) specs.push_back(c.spec);
+    return specs;
+}
+
+static const std::vector<ColumnWithMember<PhotoMeshRow>> kPmColumns = {
+    {{"Project Name",            "Project Overview",  26.0, false}, &PhotoMeshRow::projectName},
+    {{"Export Type",             "Project Overview",  18.0, false}, &PhotoMeshRow::exportType},
+    {{"Resolution",              "Project Overview",  14.0, false}, &PhotoMeshRow::resolution},
+    {{"Tile Scheme",             "Project Overview",  14.0, false}, &PhotoMeshRow::tileScheme},
+    {{"Build ID",                "Project Overview",  16.0, false}, &PhotoMeshRow::buildID},
+
+    {{"Start Time",              "Timing",            20.0, false}, &PhotoMeshRow::startTime},
+    {{"End Time",                "Timing",            20.0, false}, &PhotoMeshRow::endTime},
+    {{"Duration (hh:mm:ss)",     "Timing",            18.0, false}, &PhotoMeshRow::duration},
+
+    {{"Computer Name",           "Machine",           22.0, false}, &PhotoMeshRow::machine},
+    {{"Host IP",                 "Machine",           16.0, false}, &PhotoMeshRow::hostIP},
+    {{"User",                    "Machine",           16.0, false}, &PhotoMeshRow::user},
+
+    {{"Photos Used",             "Resources",         12.0, false}, &PhotoMeshRow::photosUsed},
+    {{"Photo Folders",           "Resources",         28.0, true }, &PhotoMeshRow::photoFolders},
+    {{"Photo Coverage (km²)",    "Resources",         16.0, false}, &PhotoMeshRow::photoCoverage},
+    {{"Fusers Used",             "Resources",         12.0, false}, &PhotoMeshRow::fusersUsed},
+    {{"CPU Threads",             "Resources",         12.0, false}, &PhotoMeshRow::cpuThreads},
+    {{"GPU Count",               "Resources",         12.0, false}, &PhotoMeshRow::gpuCount},
+
+    {{"Output Folder",           "Output",            36.0, true }, &PhotoMeshRow::outputFolder},
+    {{"Total Files",             "Output",            12.0, false}, &PhotoMeshRow::totalFiles},
+    {{"Total Size (GB)",         "Output",            14.0, false}, &PhotoMeshRow::totalSizeGB},
+
+    {{"Offset Coord Sys",        "Offsets & Settings",22.0, false}, &PhotoMeshRow::offsetCoordSys},
+    {{"Offset H Datum",          "Offsets & Settings",18.0, false}, &PhotoMeshRow::offsetHDatum},
+    {{"Offset V Datum",          "Offsets & Settings",18.0, false}, &PhotoMeshRow::offsetVDatum},
+    {{"Offset X",                "Offsets & Settings",12.0, false}, &PhotoMeshRow::offsetX},
+    {{"Offset Y",                "Offsets & Settings",12.0, false}, &PhotoMeshRow::offsetY},
+    {{"Offset Z",                "Offsets & Settings",12.0, false}, &PhotoMeshRow::offsetZ},
+    {{"Pivot Center X",          "Offsets & Settings",14.0, false}, &PhotoMeshRow::pivotCenterX},
+    {{"Pivot Center Y",          "Offsets & Settings",14.0, false}, &PhotoMeshRow::pivotCenterY},
+    {{"Pivot Center Z",          "Offsets & Settings",14.0, false}, &PhotoMeshRow::pivotCenterZ},
+    {{"Flip YZ",                 "Offsets & Settings",10.0, false}, &PhotoMeshRow::flipYZ},
+    {{"Trim",                    "Offsets & Settings",10.0, false}, &PhotoMeshRow::trim},
+    {{"Collision",               "Offsets & Settings",12.0, false}, &PhotoMeshRow::collision},
+    {{"Visual LOD",              "Offsets & Settings",12.0, false}, &PhotoMeshRow::visualLOD},
+
+    {{"Success",                 "Status",            10.0, false}, &PhotoMeshRow::success},
+    {{"Warnings",                "Status",            26.0, true }, &PhotoMeshRow::warnings},
+    {{"Errors",                  "Status",            26.0, true }, &PhotoMeshRow::errors},
+    {{"Log Path",                "Status",            42.0, true }, &PhotoMeshRow::logPath},
+};
+
+static const std::vector<ColumnWithMember<RealityMeshRow>> kRmColumns = {
+    {{"Project Name",            "Project Overview",  26.0, false}, &RealityMeshRow::projectName},
+    {{"Dataset Name",            "Project Overview",  24.0, false}, &RealityMeshRow::datasetName},
+    {{"Export Type",             "Project Overview",  18.0, false}, &RealityMeshRow::exportType},
+    {{"Process Preset",          "Project Overview",  18.0, false}, &RealityMeshRow::processPreset},
+    {{"Selection Area (km²)",    "Project Overview",  18.0, false}, &RealityMeshRow::selAreaSize},
+    {{"Resolution",              "Project Overview",  14.0, false}, &RealityMeshRow::resolution},
+    {{"Tile Scheme",             "Project Overview",  14.0, false}, &RealityMeshRow::tileScheme},
+
+    {{"Start Time",              "Timing",            20.0, false}, &RealityMeshRow::startTime},
+    {{"End Time",                "Timing",            20.0, false}, &RealityMeshRow::endTime},
+    {{"Duration (hh:mm:ss)",     "Timing",            18.0, false}, &RealityMeshRow::duration},
+
+    {{"Computer Name",           "Machine",           22.0, false}, &RealityMeshRow::machine},
+    {{"Host IP",                 "Machine",           16.0, false}, &RealityMeshRow::hostIP},
+    {{"User",                    "Machine",           16.0, false}, &RealityMeshRow::user},
+
+    {{"Output Folder",           "Output",            36.0, true }, &RealityMeshRow::outputFolder},
+    {{"Total Files",             "Output",            12.0, false}, &RealityMeshRow::totalFiles},
+    {{"Total Size (GB)",         "Output",            14.0, false}, &RealityMeshRow::totalSizeGB},
+
+    {{"Offset Coord Sys",        "Offsets & Settings",22.0, false}, &RealityMeshRow::offsetCoordSys},
+    {{"Offset H Datum",          "Offsets & Settings",18.0, false}, &RealityMeshRow::offsetHDatum},
+    {{"Offset V Datum",          "Offsets & Settings",18.0, false}, &RealityMeshRow::offsetVDatum},
+    {{"Offset X",                "Offsets & Settings",12.0, false}, &RealityMeshRow::offsetX},
+    {{"Offset Y",                "Offsets & Settings",12.0, false}, &RealityMeshRow::offsetY},
+    {{"Offset Z",                "Offsets & Settings",12.0, false}, &RealityMeshRow::offsetZ},
+    {{"Pivot Center X",          "Offsets & Settings",14.0, false}, &RealityMeshRow::pivotCenterX},
+    {{"Pivot Center Y",          "Offsets & Settings",14.0, false}, &RealityMeshRow::pivotCenterY},
+    {{"Pivot Center Z",          "Offsets & Settings",14.0, false}, &RealityMeshRow::pivotCenterZ},
+    {{"Flip YZ",                 "Offsets & Settings",10.0, false}, &RealityMeshRow::flipYZ},
+    {{"Trim",                    "Offsets & Settings",10.0, false}, &RealityMeshRow::trim},
+    {{"Collision",               "Offsets & Settings",12.0, false}, &RealityMeshRow::collision},
+
+    {{"Success",                 "Status",            10.0, false}, &RealityMeshRow::success},
+    {{"Warnings",                "Status",            26.0, true }, &RealityMeshRow::warnings},
+    {{"Errors",                  "Status",            26.0, true }, &RealityMeshRow::errors},
+    {{"Log Path",                "Status",            42.0, true }, &RealityMeshRow::logPath},
+};
+
+static const std::vector<ColumnWithMember<SummaryRow>> kSummaryColumns = {
+    {{"Project Name",            "At a Glance",       28.0, false}, &SummaryRow::projectName},
+    {{"Computer Name",           "At a Glance",       22.0, false}, &SummaryRow::machine},
+    {{"Run Date",                "At a Glance",       14.0, false}, &SummaryRow::runDate},
+    {{"Duration (hh:mm:ss)",     "At a Glance",       16.0, false}, &SummaryRow::duration},
+    {{"Total Size (GB)",         "At a Glance",       14.0, false}, &SummaryRow::totalSizeGB},
+
+    {{"Tool",                    "Details",           16.0, false}, &SummaryRow::tool},
+    {{"Export Type",             "Details",           20.0, false}, &SummaryRow::exportType},
+
+    {{"Photos Used",             "Resources",         12.0, false}, &SummaryRow::photosUsed},
+    {{"Fusers Used",             "Resources",         12.0, false}, &SummaryRow::fusersUsed},
+
+    {{"Success",                 "Status",            10.0, false}, &SummaryRow::success},
+    {{"Errors",                  "Status",            26.0, true }, &SummaryRow::errors},
+};
+
+void write_sectioned_table(lxw_workbook* wb,
+                           lxw_worksheet* ws,
+                           const std::vector<ColumnSpec>& columns,
+                           const std::vector<std::vector<std::string>>& rows) {
+    if (columns.empty()) return;
+
+    lxw_format* group_fmt = workbook_add_format(wb);
+    format_set_align(group_fmt, LXW_ALIGN_CENTER);
+    format_set_align(group_fmt, LXW_ALIGN_VERTICAL_CENTER);
+    format_set_bold(group_fmt);
+    format_set_bg_color(group_fmt, 0xD9E1F2);
+
+    lxw_format* header_fmt = workbook_add_format(wb);
+    format_set_align(header_fmt, LXW_ALIGN_CENTER);
+    format_set_align(header_fmt, LXW_ALIGN_VERTICAL_CENTER);
+    format_set_bold(header_fmt);
+    format_set_bg_color(header_fmt, 0xEEF2F7);
+
+    lxw_format* wrap_fmt = workbook_add_format(wb);
+    format_set_text_wrap(wrap_fmt);
+    format_set_align(wrap_fmt, LXW_ALIGN_TOP);
+
+    worksheet_set_row(ws, 0, 22.0, nullptr);
+    worksheet_set_row(ws, 1, 20.0, nullptr);
+
+    size_t col = 0;
+    while (col < columns.size()) {
+        const auto& spec = columns[col];
+        if (!spec.group.empty()) {
+            size_t end = col;
+            while (end + 1 < columns.size() && columns[end + 1].group == spec.group) {
+                ++end;
+            }
+            worksheet_merge_range(ws, 0, col, 0, end, spec.group.c_str(), group_fmt);
+            col = end + 1;
+        } else {
+            worksheet_write_string(ws, 0, col, "", group_fmt);
+            ++col;
+        }
+    }
+
+    for (size_t c = 0; c < columns.size(); ++c) {
+        worksheet_write_string(ws, 1, c, columns[c].title.c_str(), header_fmt);
+        worksheet_set_column(ws, c, c, columns[c].width,
+                             columns[c].wrap ? wrap_fmt : nullptr);
+    }
+
+    for (size_t r = 0; r < rows.size(); ++r) {
+        for (size_t c = 0; c < rows[r].size(); ++c) {
+            worksheet_write_string(ws, static_cast<lxw_row_t>(r + 2),
+                                   static_cast<lxw_col_t>(c), rows[r][c].c_str(), nullptr);
+        }
+    }
+
+    lxw_row_t last_row = rows.empty() ? 1 : static_cast<lxw_row_t>(rows.size() + 1);
+    worksheet_add_table(ws, 1, 0, last_row, static_cast<lxw_col_t>(columns.size() - 1), nullptr);
+    worksheet_freeze_panes(ws, 2, 0);
+}
+
+size_t find_column_index(const std::vector<ColumnSpec>& cols, const std::string& title) {
+    for (size_t i = 0; i < cols.size(); ++i) {
+        if (cols[i].title == title) return i;
+    }
+    return cols.size();
+}
+
+void add_success_format(lxw_workbook* wb,
+                        lxw_worksheet* ws,
+                        size_t success_col,
+                        size_t row_count) {
+    if (success_col >= LXW_COL_MAX || row_count == 0) return;
+
+    lxw_format* green = workbook_add_format(wb);
     format_set_bg_color(green, LXW_COLOR_GREEN);
     lxw_conditional_format cf1{};
     cf1.type = LXW_CONDITIONAL_TYPE_CELL;
     cf1.criteria = LXW_CONDITIONAL_CRITERIA_EQUAL_TO;
     cf1.value_string = const_cast<char*>("True");
     cf1.format = green;
-    worksheet_conditional_format_range(ws,1,col,rows,col,&cf1);
+    worksheet_conditional_format_range(
+        ws, 2, static_cast<lxw_col_t>(success_col),
+        static_cast<lxw_row_t>(row_count + 1), static_cast<lxw_col_t>(success_col), &cf1);
 
-    lxw_format *red = workbook_add_format(wb);
+    lxw_format* red = workbook_add_format(wb);
     format_set_bg_color(red, LXW_COLOR_RED);
     lxw_conditional_format cf2{};
     cf2.type = LXW_CONDITIONAL_TYPE_CELL;
     cf2.criteria = LXW_CONDITIONAL_CRITERIA_EQUAL_TO;
     cf2.value_string = const_cast<char*>("False");
     cf2.format = red;
-    worksheet_conditional_format_range(ws,1,col,rows,col,&cf2);
+    worksheet_conditional_format_range(
+        ws, 2, static_cast<lxw_col_t>(success_col),
+        static_cast<lxw_row_t>(row_count + 1), static_cast<lxw_col_t>(success_col), &cf2);
 }
 
-void write_workbook(const std::string &path,
-                    const std::vector<PhotoMeshRow> &pm,
-                    const std::vector<RealityMeshRow> &rm,
-                    const std::vector<SummaryRow> &summary) {
-    lxw_workbook *wb = workbook_new(path.c_str());
-    lxw_worksheet *ws_pm = workbook_add_worksheet(wb, "PhotoMesh_Exports");
-    lxw_worksheet *ws_rm = workbook_add_worksheet(wb, "RealityMesh_Exports");
-    lxw_worksheet *ws_sum = workbook_add_worksheet(wb, "Summary");
+} // namespace
 
-    std::vector<std::vector<std::string>> pm_rows;
-    for (const auto &r: pm) {
-        pm_rows.push_back({r.projectName,r.buildID,r.machine,r.hostIP,r.user,r.startTime,r.endTime,r.duration,r.exportType,r.resolution,r.tileScheme,r.photosUsed,r.photoFolders,r.photoCoverage,r.fusersUsed,r.cpuThreads,r.gpuCount,r.outputFolder,r.totalFiles,r.totalSizeGB,r.offsetCoordSys,r.offsetHDatum,r.offsetVDatum,r.offsetX,r.offsetY,r.offsetZ,r.pivotCenterX,r.pivotCenterY,r.pivotCenterZ,r.flipYZ,r.trim,r.collision,r.visualLOD,r.success,r.warnings,r.errors,r.logPath});
+namespace excel {
+
+void write_workbook(const std::string& path,
+                    const std::vector<PhotoMeshRow>& pm,
+                    const std::vector<RealityMeshRow>& rm,
+                    const std::vector<SummaryRow>& summary) {
+    lxw_workbook* wb = workbook_new(path.c_str());
+    lxw_worksheet* ws_pm = workbook_add_worksheet(wb, "PhotoMesh_Exports");
+    lxw_worksheet* ws_rm = workbook_add_worksheet(wb, "RealityMesh_Exports");
+    lxw_worksheet* ws_sum = workbook_add_worksheet(wb, "Summary");
+
+    std::vector<PhotoMeshRow> pm_sorted(pm.begin(), pm.end());
+    std::sort(pm_sorted.begin(), pm_sorted.end(), [](const PhotoMeshRow& a, const PhotoMeshRow& b) {
+        auto ta = parse_time_or_min(a.startTime, a.endTime);
+        auto tb = parse_time_or_min(b.startTime, b.endTime);
+        if (ta != tb) return ta > tb;
+        return a.projectName < b.projectName;
+    });
+    auto pm_rows = materialize_rows(pm_sorted, kPmColumns);
+    auto pm_specs = collect_specs(kPmColumns);
+    write_sectioned_table(wb, ws_pm, pm_specs, pm_rows);
+    add_success_format(wb, ws_pm, find_column_index(pm_specs, "Success"), pm_rows.size());
+
+    std::vector<RealityMeshRow> rm_sorted(rm.begin(), rm.end());
+    std::sort(rm_sorted.begin(), rm_sorted.end(), [](const RealityMeshRow& a, const RealityMeshRow& b) {
+        auto ta = parse_time_or_min(a.startTime, a.endTime);
+        auto tb = parse_time_or_min(b.startTime, b.endTime);
+        if (ta != tb) return ta > tb;
+        return a.projectName < b.projectName;
+    });
+    auto rm_rows = materialize_rows(rm_sorted, kRmColumns);
+    auto rm_specs = collect_specs(kRmColumns);
+    write_sectioned_table(wb, ws_rm, rm_specs, rm_rows);
+    add_success_format(wb, ws_rm, find_column_index(rm_specs, "Success"), rm_rows.size());
+
+    std::vector<SummaryRow> summary_sorted(summary.begin(), summary.end());
+    std::sort(summary_sorted.begin(), summary_sorted.end(), [](const SummaryRow& a, const SummaryRow& b) {
+        auto ta = parse_date_or_min(a.runDate);
+        auto tb = parse_date_or_min(b.runDate);
+        if (ta != tb) return ta > tb;
+        if (a.projectName != b.projectName) return a.projectName < b.projectName;
+        return a.machine < b.machine;
+    });
+    auto sum_rows = materialize_rows(summary_sorted, kSummaryColumns);
+    auto sum_specs = collect_specs(kSummaryColumns);
+    write_sectioned_table(wb, ws_sum, sum_specs, sum_rows);
+    add_success_format(wb, ws_sum, find_column_index(sum_specs, "Success"), sum_rows.size());
+
+    lxw_worksheet* ws_how = workbook_add_worksheet(wb, "HowTo");
+    worksheet_write_string(ws_how, 0, 0, "Usage:", nullptr);
+    worksheet_write_string(ws_how, 1, 0,
+                           "logtoExcel --photomesh pm.log --realitymesh rm.log -o Report.xlsx",
+                           nullptr);
+
+    lxw_worksheet* ws_dict = workbook_add_worksheet(wb, "Data_Dictionary");
+    worksheet_write_string(ws_dict, 0, 0, "Field", nullptr);
+    worksheet_write_string(ws_dict, 0, 1, "Description", nullptr);
+    std::set<std::string> fields;
+    for (const auto& c : kPmColumns) fields.insert(c.spec.title);
+    for (const auto& c : kRmColumns) fields.insert(c.spec.title);
+    for (const auto& c : kSummaryColumns) fields.insert(c.spec.title);
+    int row = 1;
+    for (const auto& f : fields) {
+        worksheet_write_string(ws_dict, row, 0, f.c_str(), nullptr);
+        worksheet_write_string(ws_dict, row, 1, "See README", nullptr);
+        ++row;
     }
-    write_rows(ws_pm,pm_headers,pm_rows);
-    add_success_format(wb,ws_pm,34,pm_rows.size());
-
-    std::vector<std::vector<std::string>> rm_rows;
-    for (const auto &r: rm) {
-        rm_rows.push_back({r.projectName,r.datasetName,r.machine,r.hostIP,r.user,r.startTime,r.endTime,r.duration,r.processPreset,r.exportType,r.selAreaSize,r.resolution,r.tileScheme,r.offsetCoordSys,r.offsetHDatum,r.offsetVDatum,r.offsetX,r.offsetY,r.offsetZ,r.flipYZ,r.trim,r.collision,r.outputFolder,r.totalFiles,r.totalSizeGB,r.success,r.warnings,r.errors,r.logPath});
-    }
-    write_rows(ws_rm,rm_headers,rm_rows);
-    add_success_format(wb,ws_rm,25,rm_rows.size());
-
-    std::vector<std::vector<std::string>> sum_rows;
-    for (const auto &r: summary) {
-        sum_rows.push_back({r.projectName,r.runDate,r.tool,r.exportType,r.duration,r.totalSizeGB,r.photosUsed,r.fusersUsed,r.machine,r.success,r.errors});
-    }
-    write_rows(ws_sum,summary_headers,sum_rows);
-    add_success_format(wb,ws_sum,9,sum_rows.size());
-
-    lxw_worksheet *ws_how = workbook_add_worksheet(wb, "HowTo");
-    worksheet_write_string(ws_how,0,0,"Usage:",NULL);
-    worksheet_write_string(ws_how,1,0,"logtoExcel --photomesh pm.log --realitymesh rm.log -o Report.xlsx",NULL);
-
-    lxw_worksheet *ws_dict = workbook_add_worksheet(wb, "Data_Dictionary");
-    worksheet_write_string(ws_dict,0,0,"Field",NULL);
-    worksheet_write_string(ws_dict,0,1,"Description",NULL);
-    std::set<std::string> fields(pm_headers.begin(),pm_headers.end());
-    fields.insert(rm_headers.begin(),rm_headers.end());
-    fields.insert(summary_headers.begin(),summary_headers.end());
-    int r=1; for (auto &f: fields) {
-        worksheet_write_string(ws_dict,r,0,f.c_str(),NULL);
-        worksheet_write_string(ws_dict,r,1,"See README",NULL);
-        ++r;
-    }
-    worksheet_set_column(ws_dict,0,1,30,NULL);
+    worksheet_set_column(ws_dict, 0, 1, 32.0, nullptr);
 
     workbook_close(wb);
 }

--- a/src/gui_main.cpp
+++ b/src/gui_main.cpp
@@ -35,6 +35,18 @@
 
 namespace fs = std::filesystem;
 
+#ifndef PROCESS_DPI_AWARENESS
+typedef enum PROCESS_DPI_AWARENESS {
+    PROCESS_DPI_UNAWARE = 0,
+    PROCESS_SYSTEM_DPI_AWARE = 1,
+    PROCESS_PER_MONITOR_DPI_AWARE = 2
+} PROCESS_DPI_AWARENESS;
+#endif
+
+#ifndef DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
+#define DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 ((DPI_AWARENESS_CONTEXT)-4)
+#endif
+
 // ---------- Theming ----------
 struct Theme {
     bool    dark = false;
@@ -124,8 +136,34 @@ static void apply_backdrop(HWND hwnd) {
 
 // Opt‑in per‑monitor DPI (sharp text)
 static void enable_per_monitor_dpi() {
-    // On older SDKs this may be unavailable; ignore failure
-    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    HMODULE user32 = ::GetModuleHandleW(L"user32.dll");
+    if (user32) {
+        using SetDpiContextFn = BOOL (WINAPI *)(DPI_AWARENESS_CONTEXT);
+        auto set_ctx = reinterpret_cast<SetDpiContextFn>(
+            ::GetProcAddress(user32, "SetProcessDpiAwarenessContext"));
+        if (set_ctx && set_ctx(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)) {
+            return;
+        }
+    }
+
+    HMODULE shcore = ::LoadLibraryW(L"shcore.dll");
+    if (shcore) {
+        using SetAwarenessFn = HRESULT (WINAPI *)(PROCESS_DPI_AWARENESS);
+        auto set_awareness = reinterpret_cast<SetAwarenessFn>(
+            ::GetProcAddress(shcore, "SetProcessDpiAwareness"));
+        if (set_awareness && SUCCEEDED(set_awareness(PROCESS_PER_MONITOR_DPI_AWARE))) {
+            ::FreeLibrary(shcore);
+            return;
+        }
+        ::FreeLibrary(shcore);
+    }
+
+    if (user32) {
+        using LegacyFn = BOOL (WINAPI *)(void);
+        auto set_dpiaware = reinterpret_cast<LegacyFn>(
+            ::GetProcAddress(user32, "SetProcessDPIAware"));
+        if (set_dpiaware) set_dpiaware();
+    }
 }
 
 // ---------------------- small helpers ----------------------

--- a/src/single_sheet_writer.cpp
+++ b/src/single_sheet_writer.cpp
@@ -3,12 +3,14 @@
 #include <xlsxwriter.h>
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -47,6 +49,15 @@ static const std::vector<std::string> kHeaders = {
  "Success","Warnings","Errors","LogPath","IngestedAt"
 };
 
+inline std::string normalize_header(const std::string& s) {
+  std::string out;
+  out.reserve(s.size());
+  for (unsigned char ch : s) {
+    if (std::isalnum(ch)) out.push_back(static_cast<char>(std::tolower(ch)));
+  }
+  return out;
+}
+
 inline std::string to_tsv(const std::vector<std::string>& cells) {
   std::ostringstream os;
   for (size_t i=0;i<cells.size();++i) {
@@ -68,6 +79,175 @@ inline std::vector<std::string> split_tsv(const std::string& line) {
   }
   out.push_back(cur);
   return out;
+}
+
+struct ColumnSpec {
+  std::string title;
+  std::string group;
+  double      width;
+  bool        wrap;
+};
+
+struct ColumnLayout {
+  std::string key;
+  ColumnSpec spec;
+};
+
+static const std::vector<ColumnLayout> kMasterLayout = {
+  {"ProjectName",      {"Project Name",         "At a Glance",       28.0, false}},
+  {"Machine",          {"Computer Name",        "At a Glance",       22.0, false}},
+  {"Tool",             {"Tool",                 "At a Glance",       16.0, false}},
+  {"DatasetName",      {"Dataset Name",         "At a Glance",       24.0, false}},
+  {"ExportType",       {"Export Type",          "At a Glance",       20.0, false}},
+  {"ProcessPreset",    {"Process Preset",       "At a Glance",       18.0, false}},
+  {"StartTime",        {"Start Time",           "At a Glance",       20.0, false}},
+  {"EndTime",          {"End Time",             "At a Glance",       20.0, false}},
+  {"Duration(hh:mm:ss)",{"Duration (hh:mm:ss)", "At a Glance",       16.0, false}},
+  {"RunDate",          {"Run Date",             "At a Glance",       14.0, false}},
+  {"TotalSize(GB)",    {"Total Size (GB)",      "At a Glance",       14.0, false}},
+
+  {"BuildID",          {"Build ID",             "Project Setup",     16.0, false}},
+  {"SelAreaSize(km²)", {"Selection Area (km²)", "Project Setup",     18.0, false}},
+  {"Resolution",       {"Resolution",           "Project Setup",     14.0, false}},
+  {"TileScheme",       {"Tile Scheme",          "Project Setup",     14.0, false}},
+
+  {"PhotosUsed",       {"Photos Used",          "Resources",         12.0, false}},
+  {"PhotoFolders",     {"Photo Folders",        "Resources",         28.0, true }},
+  {"PhotoCoverage(km²)",{"Photo Coverage (km²)","Resources",         18.0, false}},
+  {"FusersUsed",       {"Fusers Used",          "Resources",         12.0, false}},
+  {"CPUThreads",       {"CPU Threads",          "Resources",         12.0, false}},
+  {"GPUCount",         {"GPU Count",            "Resources",         12.0, false}},
+
+  {"HostIP",           {"Host IP",              "Environment",       16.0, false}},
+  {"User",             {"User",                 "Environment",       16.0, false}},
+
+  {"OutputFolder",     {"Output Folder",        "Output",            36.0, true }},
+  {"TotalFiles",       {"Total Files",          "Output",            12.0, false}},
+  {"LogPath",          {"Log Path",             "Output",            40.0, true }},
+
+  {"Offset_CoordSys",  {"Offset Coord Sys",     "Offsets & Settings",22.0, false}},
+  {"Offset_HDatum",    {"Offset H Datum",       "Offsets & Settings",18.0, false}},
+  {"Offset_VDatum",    {"Offset V Datum",       "Offsets & Settings",18.0, false}},
+  {"OffsetX",          {"Offset X",             "Offsets & Settings",12.0, false}},
+  {"OffsetY",          {"Offset Y",             "Offsets & Settings",12.0, false}},
+  {"OffsetZ",          {"Offset Z",             "Offsets & Settings",12.0, false}},
+  {"PivotCenterX",     {"Pivot Center X",       "Offsets & Settings",14.0, false}},
+  {"PivotCenterY",     {"Pivot Center Y",       "Offsets & Settings",14.0, false}},
+  {"PivotCenterZ",     {"Pivot Center Z",       "Offsets & Settings",14.0, false}},
+  {"FlipYZ",           {"Flip YZ",              "Offsets & Settings",10.0, false}},
+  {"Trim",             {"Trim",                 "Offsets & Settings",10.0, false}},
+  {"Collision",        {"Collision",            "Offsets & Settings",12.0, false}},
+  {"VisualLOD",        {"Visual LOD",           "Offsets & Settings",12.0, false}},
+
+  {"Success",         {"Success",              "Status",            10.0, false}},
+  {"Warnings",        {"Warnings",             "Status",            26.0, true }},
+  {"Errors",          {"Errors",               "Status",            26.0, true }},
+
+  {"IngestedAt",      {"Ingested At",          "Metadata",          20.0, false}},
+};
+
+void write_sectioned_table(lxw_workbook* wb,
+                           lxw_worksheet* ws,
+                           const std::vector<ColumnSpec>& columns,
+                           const std::vector<std::vector<std::string>>& rows) {
+  if (columns.empty()) return;
+
+  lxw_format* group_fmt = workbook_add_format(wb);
+  format_set_align(group_fmt, LXW_ALIGN_CENTER);
+  format_set_align(group_fmt, LXW_ALIGN_VERTICAL_CENTER);
+  format_set_bold(group_fmt);
+  format_set_bg_color(group_fmt, 0xD9E1F2);
+
+  lxw_format* header_fmt = workbook_add_format(wb);
+  format_set_align(header_fmt, LXW_ALIGN_CENTER);
+  format_set_align(header_fmt, LXW_ALIGN_VERTICAL_CENTER);
+  format_set_bold(header_fmt);
+  format_set_bg_color(header_fmt, 0xEEF2F7);
+
+  lxw_format* wrap_fmt = workbook_add_format(wb);
+  format_set_text_wrap(wrap_fmt);
+  format_set_align(wrap_fmt, LXW_ALIGN_TOP);
+
+  worksheet_set_row(ws, 0, 22.0, nullptr);
+  worksheet_set_row(ws, 1, 20.0, nullptr);
+
+  size_t col = 0;
+  while (col < columns.size()) {
+    const auto& spec = columns[col];
+    if (!spec.group.empty()) {
+      size_t end = col;
+      while (end + 1 < columns.size() && columns[end + 1].group == spec.group) {
+        ++end;
+      }
+      worksheet_merge_range(ws, 0, col, 0, end, spec.group.c_str(), group_fmt);
+      col = end + 1;
+    } else {
+      worksheet_write_string(ws, 0, col, "", group_fmt);
+      ++col;
+    }
+  }
+
+  for (size_t c = 0; c < columns.size(); ++c) {
+    worksheet_write_string(ws, 1, static_cast<lxw_col_t>(c),
+                           columns[c].title.c_str(), header_fmt);
+    worksheet_set_column(ws, static_cast<lxw_col_t>(c), static_cast<lxw_col_t>(c),
+                         columns[c].width, columns[c].wrap ? wrap_fmt : nullptr);
+  }
+
+  for (size_t r = 0; r < rows.size(); ++r) {
+    for (size_t c = 0; c < rows[r].size(); ++c) {
+      worksheet_write_string(ws, static_cast<lxw_row_t>(r + 2),
+                             static_cast<lxw_col_t>(c), rows[r][c].c_str(), nullptr);
+    }
+  }
+
+  lxw_row_t last_row = rows.empty() ? 1 : static_cast<lxw_row_t>(rows.size() + 1);
+  worksheet_add_table(ws, 1, 0, last_row, static_cast<lxw_col_t>(columns.size() - 1), nullptr);
+  worksheet_freeze_panes(ws, 2, 0);
+}
+
+size_t find_column_index(const std::vector<ColumnSpec>& cols, const std::string& title) {
+  for (size_t i = 0; i < cols.size(); ++i) {
+    if (cols[i].title == title) return i;
+  }
+  return cols.size();
+}
+
+void add_success_format(lxw_workbook* wb,
+                        lxw_worksheet* ws,
+                        size_t success_col,
+                        size_t row_count) {
+  if (success_col >= LXW_COL_MAX || row_count == 0) return;
+
+  lxw_format* green = workbook_add_format(wb);
+  format_set_bg_color(green, LXW_COLOR_GREEN);
+  lxw_conditional_format cf1{};
+  cf1.type = LXW_CONDITIONAL_TYPE_CELL;
+  cf1.criteria = LXW_CONDITIONAL_CRITERIA_EQUAL_TO;
+  cf1.value_string = const_cast<char*>("True");
+  cf1.format = green;
+  worksheet_conditional_format_range(
+      ws, 2, static_cast<lxw_col_t>(success_col),
+      static_cast<lxw_row_t>(row_count + 1), static_cast<lxw_col_t>(success_col), &cf1);
+
+  lxw_format* red = workbook_add_format(wb);
+  format_set_bg_color(red, LXW_COLOR_RED);
+  lxw_conditional_format cf2{};
+  cf2.type = LXW_CONDITIONAL_TYPE_CELL;
+  cf2.criteria = LXW_CONDITIONAL_CRITERIA_EQUAL_TO;
+  cf2.value_string = const_cast<char*>("False");
+  cf2.format = red;
+  worksheet_conditional_format_range(
+      ws, 2, static_cast<lxw_col_t>(success_col),
+      static_cast<lxw_row_t>(row_count + 1), static_cast<lxw_col_t>(success_col), &cf2);
+}
+
+size_t index_in_layout(const std::vector<ColumnLayout>& layout, const std::string& key) {
+  const std::string norm = normalize_header(key);
+  for (size_t i = 0; i < layout.size(); ++i) {
+    if (normalize_header(layout[i].key) == norm) return i;
+  }
+  return layout.size();
 }
 
 } // namespace
@@ -159,7 +339,10 @@ static void append_unique_to_tsv(const std::string& tsv_path,
     if (std::getline(in, line)) {
       auto hdr = split_tsv(line);
       int idx = -1;
-      for (size_t i=0;i<hdr.size();++i) if (hdr[i] == "LogPath") { idx = (int)i; break; }
+      const std::string target = normalize_header("LogPath");
+      for (size_t i=0;i<hdr.size();++i) {
+        if (normalize_header(hdr[i]) == target) { idx = static_cast<int>(i); break; }
+      }
       if (idx >= 0) {
         while (std::getline(in, line)) {
           if (line.empty()) continue;
@@ -189,45 +372,79 @@ static void rebuild_xlsx_from_tsv(const std::string& tsv_path,
   if (!in) return;
 
   std::vector<std::string> headers;
-  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<std::string>> raw_rows;
 
   std::string line;
   if (std::getline(in, line)) headers = split_tsv(line);
   while (std::getline(in, line)) {
-    if (!line.empty()) rows.push_back(split_tsv(line));
+    if (!line.empty()) raw_rows.push_back(split_tsv(line));
   }
+
+  std::unordered_map<std::string, size_t> header_index;
+  for (size_t i = 0; i < headers.size(); ++i) {
+    header_index.emplace(normalize_header(headers[i]), i);
+  }
+
+  std::vector<std::vector<std::string>> rows;
+  rows.reserve(raw_rows.size());
+  for (const auto& row : raw_rows) {
+    std::vector<std::string> ordered;
+    ordered.reserve(kMasterLayout.size());
+    for (const auto& col : kMasterLayout) {
+      auto it = header_index.find(normalize_header(col.key));
+      if (it != header_index.end() && it->second < row.size())
+        ordered.push_back(row[it->second]);
+      else
+        ordered.emplace_back();
+    }
+    rows.push_back(std::move(ordered));
+  }
+
+  const auto start_idx   = index_in_layout(kMasterLayout, "StartTime");
+  const auto end_idx     = index_in_layout(kMasterLayout, "EndTime");
+  const auto run_idx     = index_in_layout(kMasterLayout, "RunDate");
+  const auto proj_idx    = index_in_layout(kMasterLayout, "ProjectName");
+  const auto machine_idx = index_in_layout(kMasterLayout, "Machine");
+
+  auto time_key = [&](const std::vector<std::string>& row) {
+    if (start_idx < row.size()) {
+      if (auto t = util::parse_time(row[start_idx])) return *t;
+    }
+    if (end_idx < row.size()) {
+      if (auto t = util::parse_time(row[end_idx])) return *t;
+    }
+    if (run_idx < row.size() && !row[run_idx].empty()) {
+      if (auto t = util::parse_time(row[run_idx] + " 00:00:00")) return *t;
+    }
+    return std::chrono::system_clock::time_point::min();
+  };
+
+  auto field = [](const std::vector<std::string>& row, size_t idx) -> const std::string& {
+    static const std::string empty;
+    return idx < row.size() ? row[idx] : empty;
+  };
+
+  std::sort(rows.begin(), rows.end(), [&](const auto& a, const auto& b) {
+    auto ta = time_key(a);
+    auto tb = time_key(b);
+    if (ta != tb) return ta > tb;
+    const std::string& pa = field(a, proj_idx);
+    const std::string& pb = field(b, proj_idx);
+    if (pa != pb) return pa < pb;
+    const std::string& ma = field(a, machine_idx);
+    const std::string& mb = field(b, machine_idx);
+    return ma < mb;
+  });
+
+  std::vector<ColumnSpec> specs;
+  specs.reserve(kMasterLayout.size());
+  for (const auto& col : kMasterLayout) specs.push_back(col.spec);
 
   lxw_workbook* wb = workbook_new(xlsx_path.c_str());
   lxw_worksheet* ws = workbook_add_worksheet(wb, "All_Exports");
 
-  // Write header & rows
-  for (size_t c=0;c<headers.size();++c)
-    worksheet_write_string(ws, 0, (lxw_col_t)c, headers[c].c_str(), nullptr);
-  for (size_t r=0;r<rows.size();++r)
-    for (size_t c=0;c<rows[r].size();++c)
-      worksheet_write_string(ws, (lxw_row_t)(r+1), (lxw_col_t)c, rows[r][c].c_str(), nullptr);
-
-  // Format as table, freeze header, set width
-  if (!headers.empty()) {
-    worksheet_add_table(ws, 0, 0, (lxw_row_t)rows.size(), (lxw_col_t)(headers.size()-1), nullptr);
-    worksheet_freeze_panes(ws, 1, 0);
-    worksheet_set_column(ws, 0, (lxw_col_t)(headers.size()-1), 22, nullptr);
-  }
-
-  // Conditional format for Success column
-  int success_col = -1;
-  for (size_t i=0;i<headers.size();++i) if (headers[i] == "Success") { success_col = (int)i; break; }
-  if (success_col >= 0) {
-    lxw_format* green = workbook_add_format(wb); format_set_bg_color(green, LXW_COLOR_GREEN);
-    lxw_conditional_format cf1{}; cf1.type = LXW_CONDITIONAL_TYPE_CELL; cf1.criteria = LXW_CONDITIONAL_CRITERIA_EQUAL_TO;
-    cf1.value_string = const_cast<char*>("True"); cf1.format = green;
-    worksheet_conditional_format_range(ws, 1, success_col, (lxw_row_t)rows.size(), success_col, &cf1);
-
-    lxw_format* red = workbook_add_format(wb); format_set_bg_color(red, LXW_COLOR_RED);
-    lxw_conditional_format cf2{}; cf2.type = LXW_CONDITIONAL_TYPE_CELL; cf2.criteria = LXW_CONDITIONAL_CRITERIA_EQUAL_TO;
-    cf2.value_string = const_cast<char*>("False"); cf2.format = red;
-    worksheet_conditional_format_range(ws, 1, success_col, (lxw_row_t)rows.size(), success_col, &cf2);
-  }
+  write_sectioned_table(wb, ws, specs, rows);
+  add_success_format(wb, ws, find_column_index(specs, "Success"), rows.size());
 
   workbook_close(wb);
 }


### PR DESCRIPTION
## Summary
- rewrite the PhotoMesh, RealityMesh and Summary sheets with sectioned layouts, wider headers and chronological sorting for easier reading
- reformat the master All_Exports workbook using the same grouped presentation, normalized headers and sorted rows
- guard the per-monitor DPI initialization so the GUI runs on systems without SetProcessDpiAwarenessContext

## Testing
- cmake -S . -B build *(fails: missing fmt package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca131a247c8322be915a742d5a6677

## Summary by Sourcery

Refactor Excel export to use sectioned, grouped tables with configurable column specs and chronological sorting across all sheets, and enhance GUI startup to set per-monitor DPI awareness via dynamic loading with legacy fallbacks.

New Features:
- Implement sectioned layouts with grouped headers, custom widths, and text wrapping for PhotoMesh, RealityMesh, and Summary Excel sheets
- Apply the same grouped presentation, normalized headers, and chronological sorting to the master All_Exports workbook
- Add dynamic per-monitor DPI awareness initialization with fallbacks for older Windows versions

Enhancements:
- Consolidate header definitions into ColumnSpec and ColumnWithMember templates and use generic materialize and spec-collection functions
- Normalize TSV headers by stripping non-alphanumeric characters and lowercasing for robust key matching
- Remove the old flat write_rows implementation and fmt dependency for streamlined Excel export logic